### PR TITLE
Reconfigured install.deb.yml to allow for Debian based systems

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -4,3 +4,4 @@ Contributors:
 
 * Sergei Antipov (https://github.com/UnderGreen)
 * Stefan Wienert (https://github.com/zealot128)
+* Ben Passmore (https://github.com/passbe)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ elasticsearch_version: 1.1.1                    # Elasticsearch version
 elasticsearch_download_url: https://download.elasticsearch.org/elasticsearch/elasticsearch
 elasticsearch_apt_repos:
 - 'ppa:webupd8team/java'
+elasticsearch_apt_repo_keys: []                 # Install APT keys
+                                                # Ex. elasticsearch_apt_repo_keys:
+                                                #       - server: <server name>
+                                                #         key: <key id>
 elasticsearch_apt_java_package: oracle-java7-installer
 
 elasticsearch_user: elasticsearch               # Elasticsearch user
@@ -126,6 +130,21 @@ Example:
     elasticsearch_plugins:
     - name: lukas-vlcek/bigdesk
 ```
+
+#### Debian Configuration
+
+Use the following configuration to install Java packages on Debian based systems:
+
+```yaml
+elasticsearch_apt_repos:
+  - 'deb http://ppa.launchpad.net/webupd8team/java/ubuntu precise main'
+  - 'deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu precise main'
+elasticsearch_apt_repo_keys:
+  - server: 'hkp://keyserver.ubuntu.com:80'
+    key: 'EEA14886'
+```
+
+Refer to [here](http://www.webupd8.org/2012/06/how-to-install-oracle-java-7-in-debian.html) for more information.
 
 #### License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,10 @@ elasticsearch_version: 1.5.2                    # Elasticsearch version
 elasticsearch_download_url: https://download.elastic.co/elasticsearch/elasticsearch
 elasticsearch_apt_repos:
 - 'ppa:webupd8team/java'
+elasticsearch_apt_repo_keys: []                 # Install APT keys
+                                                # Ex. elasticsearch_apt_repo_keys:
+                                                #       - server: <server name>
+                                                #         key: <key id>
 elasticsearch_apt_java_package: oracle-java7-installer
 
 elasticsearch_user: elasticsearch               # Elasticsearch user

--- a/tasks/install.deb.yml
+++ b/tasks/install.deb.yml
@@ -1,8 +1,15 @@
 ---
 
 - name: elasticsearch-install | Add repositories
-  apt_repository: repo={{item}} update_cache=yes
+  apt_repository: repo="{{item}}" update_cache=yes
   with_items: elasticsearch_apt_repos
+
+- name: elasticsearch-install | Add repository keys
+  apt_key: keyserver="{{item.server}}" id="{{item.key}}" state=present
+  with_items: elasticsearch_apt_repo_keys
+
+- name: elasticsearch-install | Update repositories
+  apt: update_cache=yes
 
 - name: elasticsearch-install | Accept Oracle license
   shell: echo debconf shared/accepted-oracle-license-v1-1 select true | sudo debconf-set-selections; echo debconf shared/accepted-oracle-license-v1-1 seen true | sudo debconf-set-selections


### PR DESCRIPTION
This commit will allow Debain based systems to install the `oracle-java7-installer` package via adding apt-key and performing and apt update before install.