### PR TITLE
ensure that node.master is set correctly

### DIFF
--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -45,6 +45,7 @@
 #
 # node.master: true
 {% if elasticsearch_node_master is defined %}node.master: {{ elasticsearch_node_master }}{% endif %}
+
 #
 # Allow this node to store data (enabled by default):
 #


### PR DESCRIPTION
It seems that the comment, at least on mac, becomes part of the specified variable, for example "true" becomes true# which makes the file unparsable.

Without this PR:
```
--- before: /etc/elasticsearch/elasticsearch.yml
+++ after: /Users/whn/code/aevy/aevy.com/ops/database-pool/vendor_roles/Stouts.elasticsearch/templates/elasticsearch.yml.j2
@@ -35,21 +35,21 @@
 # from configuring them manually. You can tie this node to a specific name:
 #
 # node.name: "Franz Kafka"
 node.name: aurelius.whn.xyz
 # Every node can be configured to allow or deny being eligible as the master,
 # and to allow or deny to store the data.
 #
 # Allow this node to be eligible as a master node (enabled by default):
 #
 # node.master: true
-node.master: false
+node.master: false#
 # Allow this node to store data (enabled by default):
 #
 # node.data: true

 # You can exploit these settings to design advanced cluster topologies.
 #
 # 1. You want this node to never become a master node, only to hold data.
 #    This will be the "workhorse" of your cluster.
 #
 # node.master: false
```

With this pr:

```
TASK: [Stouts.elasticsearch | elasticsearch-configure | Configure Elasticsearch pt. 1] ***
--- before: /etc/elasticsearch/elasticsearch.yml
+++ after: /Users/whn/code/aevy/aevy.com/ops/database-pool/vendor_roles/Stouts.elasticsearch/templates/elasticsearch.yml.j2
@@ -36,20 +36,21 @@
 #
 # node.name: "Franz Kafka"
 node.name: claudius.whn.xyz
 # Every node can be configured to allow or deny being eligible as the master,
 # and to allow or deny to store the data.
 #
 # Allow this node to be eligible as a master node (enabled by default):
 #
 # node.master: true
 node.master: true
+#
 # Allow this node to store data (enabled by default):
 #
 # node.data: true
 node.data: false
 # You can exploit these settings to design advanced cluster topologies.
 #
 # 1. You want this node to never become a master node, only to hold data.
 #    This will be the "workhorse" of your cluster.
 #
 # node.master: false
 ```