### PR TITLE
add option for indices.cache.filter.size

### DIFF
--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -482,6 +482,10 @@ action.disable_delete_all_indices: {{ elasticsearch_misc_disable_delete_all_indi
 script.groovy.sandbox.enabled: {{ elasticsearch_script_groovy_sandbox_enabled }}
 {% endif %}
 
+{% if elasticsearch_indices_cache_filter_size is defined %}
+indices.cache.filter.size: {{ elasticsearch_indices_cache_filter_size }}
+{% endif %}
+
 {% if elasticsearch_yml is defined %}
 {{ elasticsearch_yml }}
 {% endif %}


### PR DESCRIPTION
Hi there,

Thanks for making such an awesome role, literally saved me hours of work. I was wondering if it would be possible to add the indices.cache.filter.size option directly to the file so as to avoid using the custom YML parameter.

Cheers,
/will

(internal reference: aevy/intro#4438)