### PR TITLE
Fixes for Elasticsearch 2.0

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 
 elasticsearch_enabled: yes                      # The role is enabled
 elasticsearch_version: 1.7.2                    # Elasticsearch version
+
 elasticsearch_download_url: https://download.elastic.co/elasticsearch/elasticsearch
 elasticsearch_apt_repos:
 - 'ppa:webupd8team/java'
@@ -48,3 +49,6 @@ elasticsearch_proxy_auth: no                      # Enable HTTP Auth
 elasticsearch_proxy_auth_users: []                # Setup users for HTTP Auth. Example:
                                                   # elasticsearch_proxy_auth_users:
                                                   # - { name: username, password: userpassword }
+
+# internal var
+elasticsearch_2x_series: "{{ elasticsearch_version|match('^2') }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,4 +51,4 @@ elasticsearch_proxy_auth_users: []                # Setup users for HTTP Auth. E
                                                   # - { name: username, password: userpassword }
 
 # internal var
-elasticsearch_2x_series: "{{ elasticsearch_version|match('^2') }}"
+elasticsearch_1x_series: "{{ elasticsearch_version|match('^(1|0)') }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -8,6 +8,9 @@
 - name: elasticsearch-configure | Chown Elasticsearch home
   file: path={{elasticsearch_home}} state=directory owner={{elasticsearch_user}} group={{elasticsearch_group}} recurse=yes
 
+- name: elasticsearch-create-conf-dir
+  file: path={{elasticsearch_confdir}} state=directory owner={{elasticsearch_user}} group={{elasticsearch_group}} recurse=yes
+
 - name: elasticsearch-configure | Configure Elasticsearch pt. 1
   template: src=elasticsearch.yml.j2 dest={{elasticsearch_confdir}}/elasticsearch.yml owner={{elasticsearch_user}} group={{elasticsearch_group}} mode=0644
   notify: elasticsearch restart

--- a/tasks/plugins.1.yml
+++ b/tasks/plugins.1.yml
@@ -1,0 +1,18 @@
+- name: elasticsearch-plugins | Install plugins
+  command: "{{elasticsearch_home}}/bin/plugin --install {{item.name}} {%if item.url is defined %} --url {{item.url}}{% endif %} creates={{elasticsearch_plugindir}}/{{item.dir|default(item.name.split('/')[-1])}}"
+  when: item.remove is not defined or not item.remove
+  with_items: elasticsearch_plugins
+  ignore_errors: yes
+  notify: elasticsearch restart
+
+- name: elasticsearch-plugins | Remove plugins
+  command: "{{elasticsearch_home}}/bin/plugin --remove {{item.name}}"
+  when: item.remove is defined and item.remove
+  with_items: elasticsearch_plugins
+  ignore_errors: yes
+  notify: elasticsearch restart
+
+- name: elasticsearch-plugins | Chown plugins
+  file: path={{elasticsearch_plugindir}} state=directory owner={{elasticsearch_user}} group={{elasticsearch_group}} recurse=yes
+
+

--- a/tasks/plugins.2.yml
+++ b/tasks/plugins.2.yml
@@ -1,0 +1,15 @@
+- name: elasticsearch-plugins | Install plugins
+  command: "{{elasticsearch_home}}/bin/plugin install {{item.name}} creates={{elasticsearch_plugindir}}/{{item.dir|default(item.name.split('/')[-1])}}"
+  when: item.remove is not defined or not item.remove
+  with_items: elasticsearch_plugins
+  ignore_errors: yes
+  notify: elasticsearch restart
+
+- name: elasticsearch-plugins | Remove plugins
+  command: "{{elasticsearch_home}}/bin/plugin remove {{item.name}}"
+  when: item.remove is defined and item.remove
+  with_items: elasticsearch_plugins
+  ignore_errors: yes
+  notify: elasticsearch restart
+
+

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,11 +1,10 @@
 ---
 
-# The 2.0 way
 - include: plugins.2.yml
-  when: elasticsearch_1x_series == False
+  when: elasticsearch_1x_series == "False"
   tags: [elasticsearch, elasticsearch-install]
 
 # the < 2.0 way
 - include: plugins.1.yml
-  when: elasticsearch_1x_series == True
+  when: elasticsearch_1x_series == "True"
   tags: [elasticsearch, elasticsearch-install]

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,14 +1,14 @@
 ---
 
 - name: elasticsearch-plugins | Install plugins
-  command: "{{elasticsearch_home}}/bin/plugin --install {{item.name}} {%if item.url is defined %} --url {{item.url}}{% endif %} creates={{elasticsearch_plugindir}}/{{item.dir|default(item.name.split('/')[-1])}}"
+  command: "{{elasticsearch_home}}/bin/plugin install {{item.name}} creates={{elasticsearch_plugindir}}/{{item.dir|default(item.name.split('/')[-1])}}"
   when: item.remove is not defined or not item.remove
   with_items: elasticsearch_plugins
   ignore_errors: yes
   notify: elasticsearch restart
 
 - name: elasticsearch-plugins | Remove plugins
-  command: "{{elasticsearch_home}}/bin/plugin --remove {{item.name}}"
+  command: "{{elasticsearch_home}}/bin/plugin remove {{item.name}}"
   when: item.remove is defined and item.remove
   with_items: elasticsearch_plugins
   ignore_errors: yes

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,18 +1,35 @@
 ---
 
+# The 2.0 way
 - name: elasticsearch-plugins | Install plugins
   command: "{{elasticsearch_home}}/bin/plugin install {{item.name}} creates={{elasticsearch_plugindir}}/{{item.dir|default(item.name.split('/')[-1])}}"
-  when: item.remove is not defined or not item.remove
+  when: (item.remove is not defined or not item.remove) and not elasticsearch_1x_series
   with_items: elasticsearch_plugins
   ignore_errors: yes
   notify: elasticsearch restart
 
 - name: elasticsearch-plugins | Remove plugins
   command: "{{elasticsearch_home}}/bin/plugin remove {{item.name}}"
-  when: item.remove is defined and item.remove
+  when: (item.remove is defined and item.remove) and not elasticsearch_1x_series
+  with_items: elasticsearch_plugins
+  ignore_errors: yes
+  notify: elasticsearch restart
+
+# the < 2.0 way
+- name: elasticsearch-plugins | Install plugins
+  command: "{{elasticsearch_home}}/bin/plugin --install {{item.name}} {%if item.url is defined %} --url {{item.url}}{% endif %} creates={{elasticsearch_plugindir}}/{{item.dir|default(item.name.split('/')[-1])}}"
+  when: (item.remove is not defined or not item.remove) and elasticsearch_1x_series
+  with_items: elasticsearch_plugins
+  ignore_errors: yes
+  notify: elasticsearch restart
+
+- name: elasticsearch-plugins | Remove plugins
+  command: "{{elasticsearch_home}}/bin/plugin --remove {{item.name}}"
+  when: (item.remove is defined and item.remove) and elasticsearch_1x_series
   with_items: elasticsearch_plugins
   ignore_errors: yes
   notify: elasticsearch restart
 
 - name: elasticsearch-plugins | Chown plugins
   file: path={{elasticsearch_plugindir}} state=directory owner={{elasticsearch_user}} group={{elasticsearch_group}} recurse=yes
+

--- a/tasks/plugins.yml
+++ b/tasks/plugins.yml
@@ -1,35 +1,11 @@
 ---
 
 # The 2.0 way
-- name: elasticsearch-plugins | Install plugins
-  command: "{{elasticsearch_home}}/bin/plugin install {{item.name}} creates={{elasticsearch_plugindir}}/{{item.dir|default(item.name.split('/')[-1])}}"
-  when: (item.remove is not defined or not item.remove) and not elasticsearch_1x_series
-  with_items: elasticsearch_plugins
-  ignore_errors: yes
-  notify: elasticsearch restart
-
-- name: elasticsearch-plugins | Remove plugins
-  command: "{{elasticsearch_home}}/bin/plugin remove {{item.name}}"
-  when: (item.remove is defined and item.remove) and not elasticsearch_1x_series
-  with_items: elasticsearch_plugins
-  ignore_errors: yes
-  notify: elasticsearch restart
+- include: plugins.2.yml
+  when: elasticsearch_1x_series == False
+  tags: [elasticsearch, elasticsearch-install]
 
 # the < 2.0 way
-- name: elasticsearch-plugins | Install plugins
-  command: "{{elasticsearch_home}}/bin/plugin --install {{item.name}} {%if item.url is defined %} --url {{item.url}}{% endif %} creates={{elasticsearch_plugindir}}/{{item.dir|default(item.name.split('/')[-1])}}"
-  when: (item.remove is not defined or not item.remove) and elasticsearch_1x_series
-  with_items: elasticsearch_plugins
-  ignore_errors: yes
-  notify: elasticsearch restart
-
-- name: elasticsearch-plugins | Remove plugins
-  command: "{{elasticsearch_home}}/bin/plugin --remove {{item.name}}"
-  when: (item.remove is defined and item.remove) and elasticsearch_1x_series
-  with_items: elasticsearch_plugins
-  ignore_errors: yes
-  notify: elasticsearch restart
-
-- name: elasticsearch-plugins | Chown plugins
-  file: path={{elasticsearch_plugindir}} state=directory owner={{elasticsearch_user}} group={{elasticsearch_group}} recurse=yes
-
+- include: plugins.1.yml
+  when: elasticsearch_1x_series == True
+  tags: [elasticsearch, elasticsearch-install]

--- a/templates/elasticsearch.j2
+++ b/templates/elasticsearch.j2
@@ -38,7 +38,7 @@ WORK_DIR={{elasticsearch_workdir}}
 # ElasticSearch configuration directory
 CONF_DIR={{elasticsearch_confdir}}
 
-{% if elasticsearch_1x_series == True %}
+{% if elasticsearch_1x_series == "True" %}
 # ElasticSearch configuration file (elasticsearch.yml)
 CONF_FILE={{elasticsearch_confdir}}/elasticsearch.yml
 {% endif %}

--- a/templates/elasticsearch.j2
+++ b/templates/elasticsearch.j2
@@ -38,8 +38,10 @@ WORK_DIR={{elasticsearch_workdir}}
 # ElasticSearch configuration directory
 CONF_DIR={{elasticsearch_confdir}}
 
+{% if elasticsearch_version is not "2.0.0" }
 # ElasticSearch configuration file (elasticsearch.yml)
 CONF_FILE={{elasticsearch_confdir}}/elasticsearch.yml
+{% endif %}
 
 # Additional Java OPTS
 #ES_JAVA_OPTS=

--- a/templates/elasticsearch.j2
+++ b/templates/elasticsearch.j2
@@ -38,10 +38,9 @@ WORK_DIR={{elasticsearch_workdir}}
 # ElasticSearch configuration directory
 CONF_DIR={{elasticsearch_confdir}}
 
-# {{ elasticsearch_2x_series }}
-{% if elasticsearch_2x_series  == ""  %}
+{% if elasticsearch_1x_series == True %}
 # ElasticSearch configuration file (elasticsearch.yml)
-# CONF_FILE={{elasticsearch_confdir}}/elasticsearch.yml
+CONF_FILE={{elasticsearch_confdir}}/elasticsearch.yml
 {% endif %}
 
 # Additional Java OPTS

--- a/templates/elasticsearch.j2
+++ b/templates/elasticsearch.j2
@@ -38,7 +38,7 @@ WORK_DIR={{elasticsearch_workdir}}
 # ElasticSearch configuration directory
 CONF_DIR={{elasticsearch_confdir}}
 
-{% if elasticsearch_version is not "2.0.0" }
+{% if {{ elasticsearch_version }} match("^2")  %}
 # ElasticSearch configuration file (elasticsearch.yml)
 CONF_FILE={{elasticsearch_confdir}}/elasticsearch.yml
 {% endif %}

--- a/templates/elasticsearch.j2
+++ b/templates/elasticsearch.j2
@@ -38,9 +38,10 @@ WORK_DIR={{elasticsearch_workdir}}
 # ElasticSearch configuration directory
 CONF_DIR={{elasticsearch_confdir}}
 
-{% if {{ elasticsearch_version }} match("^2")  %}
+# {{ elasticsearch_2x_series }}
+{% if elasticsearch_2x_series  == ""  %}
 # ElasticSearch configuration file (elasticsearch.yml)
-CONF_FILE={{elasticsearch_confdir}}/elasticsearch.yml
+# CONF_FILE={{elasticsearch_confdir}}/elasticsearch.yml
 {% endif %}
 
 # Additional Java OPTS

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -254,7 +254,9 @@ http.cors.allow-methods: {{ elasticsearch_http_cors_allow_methods }}
 
 # The default gateway type is the "local" gateway (recommended):
 #
+{% if elasticsearch_gateway_type != "local" %}
 gateway.type: {{ elasticsearch_gateway_type }}
+{% endif %}
 
 # Settings below control how and when to start the initial recovery process on
 # a full cluster restart (to reuse as much local data as possible when using shared
@@ -471,7 +473,12 @@ monitor.jvm.gc.ConcurrentMarkSweep.debug: {{ elasticsearch_gc_soncurrent_mark_sw
 
 ################################### Varia #####################################
 #
+{% if elasticsearch_1x_series == "True" %}
 script.disable_dynamic: {{elasticsearch_script_disable_dynamic}}
+{% else %}
+script.inline: {{ elasticsearch_script_disable_dynamic  }}
+script.indexed: {{ elasticsearch_script_disable_dynamic  }}
+{% endif %}
 
 {% if elasticsearch_misc_auto_create_index is defined %}
 action.auto_create_index: {{ elasticsearch_misc_auto_create_index }}


### PR DESCRIPTION
Hi!

This is not a complete pull request, but I'd like to talk about how we can address the issues I've found.

First of all, `CONF_FILE` env variable is removed from Elasticsearch 2.0, due to [security changes and its location can't be changed](https://www.elastic.co/guide/en/elasticsearch/reference/2.0/setup-configuration.html#settings).

The other issue is breaking change to `plugin` command syntax.

~~My changes effectively break the role for ES < 2.0 - it would be great if we can work out how this role could support all recent versions of Elasticsearch.~~~

~~~Other way would be to not support versions below 2.0, which of course is a bit drastic ;-)~~~

## Update
Tests pass in travis and the role seems to be working for both es 2.0 and 1.7 (not sure about 0.x series).